### PR TITLE
fix(ci): prevent PR task fan-out in Moon workflow steps

### DIFF
--- a/.github/workflows/build-backend.yml
+++ b/.github/workflows/build-backend.yml
@@ -72,12 +72,7 @@ jobs:
         run: chmod +x gradlew
 
       - name: Run tests
-        run: |
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            bunx @moonrepo/cli@${{ env.MOON_VERSION }} ci backend:test
-          else
-            bunx @moonrepo/cli@${{ env.MOON_VERSION }} run backend:test
-          fi
+        run: bunx @moonrepo/cli@${{ env.MOON_VERSION }} run backend:test
 
       - name: Build native executable
         if: inputs.externall_call

--- a/.github/workflows/build-frontend.yml
+++ b/.github/workflows/build-frontend.yml
@@ -68,23 +68,13 @@ jobs:
         run: bun install --frozen-lockfile
 
       - name: Run linter
-        run: |
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            bunx @moonrepo/cli@${{ env.MOON_VERSION }} ci frontend:lint
-          else
-            bunx @moonrepo/cli@${{ env.MOON_VERSION }} run frontend:lint
-          fi
+        run: bunx @moonrepo/cli@${{ env.MOON_VERSION }} run frontend:lint
 
       - name: Build frontend
         env:
           VITE_MAPBOX_KEY: ${{ secrets.MAPBOX_PUBLIC_ACCESS_TOKEN }}
           VITE_BACKEND_BASE_URL: https://api.hollybike.chbrx.com/api
-        run: |
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            bunx @moonrepo/cli@${{ env.MOON_VERSION }} ci frontend:build
-          else
-            bunx @moonrepo/cli@${{ env.MOON_VERSION }} run frontend:build
-          fi
+        run: bunx @moonrepo/cli@${{ env.MOON_VERSION }} run frontend:build
 
       - name: Set up Docker Buildx
         if: inputs.externall_call

--- a/.github/workflows/infrastructure.yml
+++ b/.github/workflows/infrastructure.yml
@@ -116,21 +116,11 @@ jobs:
 
       - name: Terraform format check
         id: fmt
-        run: |
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            bunx @moonrepo/cli@${{ env.MOON_VERSION }} ci infrastructure:lint
-          else
-            bunx @moonrepo/cli@${{ env.MOON_VERSION }} run infrastructure:lint
-          fi
+        run: bunx @moonrepo/cli@${{ env.MOON_VERSION }} run infrastructure:lint
 
       - name: Terraform validate
         id: validate
-        run: |
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            bunx @moonrepo/cli@${{ env.MOON_VERSION }} ci infrastructure:validate
-          else
-            bunx @moonrepo/cli@${{ env.MOON_VERSION }} run infrastructure:validate
-          fi
+        run: bunx @moonrepo/cli@${{ env.MOON_VERSION }} run infrastructure:validate
 
       - name: Normalize image names
         id: image-names


### PR DESCRIPTION
## Summary
- Prevent PR workflows from expanding into extra Moon tasks by replacing `moon ci <task>` calls with explicit `moon run <task>`.
- Keeps each workflow step scoped to only the requested task.

## Files changed
- .github/workflows/build-backend.yml
- .github/workflows/build-frontend.yml
- .github/workflows/infrastructure.yml

## Validation performed
- Searched workflow commands for all remaining `moon ci` usages (none remain).
- Verified diffs only touch task invocation logic in workflow files.

## Risks / blockers
- No local GitHub Actions execution here; behavior is validated on next CI run.